### PR TITLE
Add autoload to composer.json to avoid usage of require later on

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,4 +16,10 @@
     "require": {
         "php": ">=5.3.6"
     }
+    "autoload": {
+        "files": [
+            "src/PDO.Log.class.php",
+            "src/PDO.class.php"
+        ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.3.6"
-    }
+    },
     "autoload": {
         "files": [
             "src/PDO.Log.class.php",


### PR DESCRIPTION
From now on, after running `composer update` or `install`, you can use class `DB` without the need to require class file before.